### PR TITLE
Remove tunnel when annotated not to manage

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -602,6 +602,13 @@ func makeClient(tunnel *inletsv1alpha1.Tunnel, targetPort int32, clientImage str
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: tunnel.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(tunnel, schema.GroupVersionKind{
+					Group:   inletsv1alpha1.SchemeGroupVersion.Group,
+					Version: inletsv1alpha1.SchemeGroupVersion.Version,
+					Kind:    "Tunnel",
+				}),
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -614,13 +621,6 @@ func makeClient(tunnel *inletsv1alpha1.Tunnel, targetPort int32, clientImage str
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app.kubernetes.io/name": name,
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(tunnel, schema.GroupVersionKind{
-							Group:   inletsv1alpha1.SchemeGroupVersion.Group,
-							Version: inletsv1alpha1.SchemeGroupVersion.Version,
-							Kind:    "Tunnel",
-						}),
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Closes: #16

<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [x] I have raised an issue to propose this change.

## Description

The operator will remove an existing tunnel if the load balancer is
annotated with `dev.inlets.manage: false`


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Create a new loadblancer service

```
kubectl run nginx-1 --image=nginx --port=80 --restart=Always
kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer
```

2. Check that a new tunnels was created

```
kubectl get tunnels
```

3. Annotate the loadbalancer with `dev.inlets.manage=false`

4. Check that the tunnel was deleted and the exit node deprovisioned


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests