### PR TITLE
Add info for running on RPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ kubectl apply -f ./artifacts/operator-rbac.yaml
 kubectl apply -f ./artifacts/operator.yaml
 ```
 
+## Running on a Raspberry Pi
+
+Use the same commands as described in the section above.
+
+> There used to be separate deployment files in `artifacts` folder called `operator-amd64.yaml` and `operator-armhf.yaml`.
+> Since version `0.2.7` Docker images get built for multiple architectures with the same tag which means that there is now just one deployment file called `operator.yaml` that can be used on all supported architecures. 
+
 ## Get a LoadBalancer provided by inlets
 
 ```sh


### PR DESCRIPTION
Signed-off-by: Matevz Mihalic <matevz.mihalic@gmail.com>

## Description
Add info for running on RPi and info about changed deployment file.

Link to _Running inlets-operstor on a Raspberry Pi (armhf)_ on [blog](https://blog.alexellis.io/ingress-for-your-local-kubernetes-cluster/) should be updated. 

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
