### PR TITLE
Add annotated-only flag to opt-out by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,14 @@ spec:
   type: LoadBalancer
 ```
 
+## Annotations
+
+By default the operator will create a tunnel for every loadbalancer service.
+
 To ignore a service such as `traefik` type in: `kubectl annotate svc/traefik -n kube-system dev.inlets.manage=false`
+
+You can also set the operator to ignore the services by default and only manage them when the annotation is true. `dev.inlets.manage=true`
+To do this, run the operator with the flag `-annotated-only`
 
 ## Monitor/view logs
 

--- a/artifacts/operator.yaml
+++ b/artifacts/operator.yaml
@@ -24,6 +24,7 @@ spec:
         imagePullPolicy: Always
         command:
           - ./inlets-operator
+          # - "-annotated-only"
           - "-provider=digitalocean"
           - "-access-key-file=/var/secrets/inlets/inlets-access-key"
           # For Packet users

--- a/chart/inlets-operator/README.md
+++ b/chart/inlets-operator/README.md
@@ -26,6 +26,26 @@
     kubectl apply -f ./artifacts/crd.yaml
     ```
 
+## Configuration
+
+The following table lists the configurable parameters of the `inlets-operator` chart and their default values,
+and can be overwritten via the helm `--set` flag.
+
+Parameter | Description | Default
+---                             | ---                                                                     | ---
+`image`                 | Docker image for the Inlets Operator                                            | `inlets/inlets-operator:0.4.2`
+`clientImage`           | Docker image for the inlets client                                              | `inlets/inlets:2.6.1`
+`provider`              | Your infrastructure provider - 'packet' or 'digitalocean'                       | `""`
+`region`                | The region to provision hosts into                                              | `""`
+`accessKeyFile`         | Read the access key for your infrastructure provider from a file (recommended)  | `/var/secrets/inlets/inlets-access-key`
+`packetProjectId`       | The project ID if using Packet.com as the provider                              | `""`
+`annotatedOnly`         | Only create a tunnel for annotated services.                                    | `false`
+`inletsProLicense`      | License for use with inlets-pro                                                 | `""`
+`resources`             | Operator resources requests & limits                                            | `{"requests":{"cpu": "100m", "memory": "128Mi"}}`
+`nodeSelector`          | Node labels for data pod assignment                                             | `{}`
+`tolerations`           | Node tolerations                                                                | `[]`
+`affinity`              | Node affinity policy                                                            | `{}`
+
 ## Deploy an example configuration
 
 ### DigitalOcean with inlets OSS (recommended)

--- a/chart/inlets-operator/templates/deployment.yaml
+++ b/chart/inlets-operator/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         command:
         - ./inlets-operator
+        {{- if .Value.annotatedOnly }}
+        - "-annotated-only"
+        {{- end }}
         - "-provider={{.Values.provider}}"
         - "-access-key-file={{.Values.accessKeyFile}}"
         - "-license={{.Values.inletsProLicense}}"

--- a/chart/inlets-operator/values.yaml
+++ b/chart/inlets-operator/values.yaml
@@ -11,6 +11,8 @@ accessKeyFile: "/var/secrets/inlets/inlets-access-key"
 # Obtain from https://github.com/alexellis/inlets-pro-pkg
 inletsProLicense: ""
 
+annotatedOnly: false
+
 image: "inlets/inlets-operator:0.4.2"
 pullPolicy: "IfNotPresent"
 clientImage: "inlets/inlets:2.6.1"

--- a/controller.go
+++ b/controller.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -87,7 +88,8 @@ func NewController(
 	deploymentInformer appsinformers.DeploymentInformer,
 	tunnelInformer informers.TunnelInformer,
 	serviceInformer coreinformers.ServiceInformer,
-	infra *InfraConfig) *Controller {
+	infra *InfraConfig,
+) *Controller {
 
 	// Create event broadcaster
 	// Add sample-controller types to the default Kubernetes Scheme so Events can be
@@ -318,7 +320,7 @@ func (c *Controller) syncHandler(key string) error {
 			found, err := tunnels.Get(name, ops)
 
 			if errors.IsNotFound(err) {
-				if manageService(*service) {
+				if manageService(*c, *service) {
 					pwdRes, pwdErr := password.Generate(64, 10, 0, false, true)
 					if pwdErr != nil {
 						log.Fatalf("Error generating password for inlets server %s", pwdErr.Error())
@@ -352,7 +354,7 @@ func (c *Controller) syncHandler(key string) error {
 			} else {
 				log.Printf("Tunnel exists: %s\n", found.Name)
 
-				if manageService(*service) == false {
+				if manageService(*c, *service) == false {
 					log.Printf("Removing tunnel: %s\n", found.Name)
 
 					err := tunnels.Delete(found.Name, &metav1.DeleteOptions{})
@@ -789,12 +791,16 @@ curl -sLO https://raw.githubusercontent.com/inlets/inlets/master/hack/inlets-pro
 	systemctl enable inlets-pro`
 }
 
-func manageService(service corev1.Service) bool {
+func manageService(controller Controller, service corev1.Service) bool {
 	annotations := service.Annotations
-	if v, ok := annotations["dev.inlets.manage"]; ok && v == "false" {
-		return false
+
+	value, ok := annotations["dev.inlets.manage"]
+	if ok {
+		valueBool, _ := strconv.ParseBool(value)
+		return valueBool
 	}
-	return true
+
+	return !controller.infraConfig.AnnotatedOnly
 }
 
 func getPortsString(service *corev1.Service) string {

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ type InfraConfig struct {
 	SecretKeyFile     string
 	ProjectID         string
 	InletsClientImage string
+	AnnotatedOnly     bool
 	ProConfig         InletsProConfig
 }
 
@@ -68,6 +69,7 @@ func main() {
 	flag.StringVar(&infra.OrganizationID, "organization-id", "", "The organization id if using Scaleway as the provider")
 	flag.StringVar(&infra.ProjectID, "project-id", "", "The project ID if using Packet.com as the provider")
 	flag.StringVar(&infra.ProConfig.License, "license", "", "Supply a license for use with inlets-pro")
+	flag.BoolVar(&infra.AnnotatedOnly, "annotated-only", false, "Only create a tunnel for annotated services. Annotate with dev.inlets.manage=true.")
 
 	flag.Parse()
 


### PR DESCRIPTION
<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [x] I have raised an issue to propose this change.
  Talk about it on slack

## Description

The operator creates a tunnel for every loadbalancer services. There are
cases were you might want the operator to manage only annotated
services. Here we add the `annotated-only` flag to tell the operator to
manage only the services with the `dev.inlets.manage=true` annotation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

0. Run the operator with the `annotated-only` flag

1. Create a new loadblancer service

```
kubectl run nginx-1 --image=nginx --port=80 --restart=Always
kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer
```

2. Check that a new tunnels is not created

```
kubectl get tunnels
```

3. Annotate the loadbalancer with `dev.inlets.manage=true`

4. Check that the tunnel was created

## How are existing users impacted? What migration steps/scripts do we need?

The default behaviour is not changed

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests