### PR TITLE
Fix Google Compute link and update vendor dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -73,14 +73,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
-  name = "github.com/google/go-querystring"
-  packages = ["query"]
-  pruneopts = "UT"
-  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
-  version = "v1.0.0"
-
-[[projects]]
   digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
   packages = ["."]
@@ -126,12 +118,12 @@
   version = "v0.3.5"
 
 [[projects]]
-  digest = "1:b3d4506610922cf958f20e8ed0a1ac27ff6e1191cdabd0438f7484291e0a7579"
+  digest = "1:bcbe16508a308cebecf0cb9dc5d9dba35cb0821ddd614dcedfe34ccd1d06073d"
   name = "github.com/inlets/inletsctl"
   packages = ["pkg/provision"]
   pruneopts = "UT"
-  revision = "3bf1b42d0e76176e5818b82ea5799474fd1a388b"
-  version = "0.3.3"
+  revision = "c0b25dd347dff9dcef9ac4c676c4aef43010182c"
+  version = "0.3.4"
 
 [[projects]]
   digest = "1:eaefc85d32c03e5f0c2b88ea2f79fce3d993e2c78316d21319575dd4ea9153ca"

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ kubectl logs deploy/inlets-operator -n kube-system -f
 
 | Provider                                                           | Price per month | Price per hour |     OS image | CPU | Memory | Boot time |
 | ------------------------------------------------------------------ | --------------: | -------------: | -----------: | --: | -----: | --------: |
-| [Google Compute Engine]()                                          |         *  ~\$4.28 |       ~\$0.006 | Debian GNU Linux 9 (stretch) | 1 | 614MB | ~3-15s |
+| [Google Compute Engine](https://cloud.google.com/compute)                                          |         *  ~\$4.28 |       ~\$0.006 | Debian GNU Linux 9 (stretch) | 1 | 614MB | ~3-15s |
 | [Packet](https://www.packet.com/cloud/servers/t1-small/)           |           ~\$51 |         \$0.07 | Ubuntu 16.04 |   4 |    8GB | ~45-60s  |
 | [Digital Ocean](https://www.digitalocean.com/pricing/#Compute)     |             \$5 |      ~\$0.0068 | Ubuntu 16.04 |   1 |  512MB | ~20-30s  |
 | [Scaleway](https://www.scaleway.com/en/pricing/#virtual-instances) |           2.99€ |         0.006€ | Ubuntu 18.04 |   2 |    2GB | 3-5m      |

--- a/vendor/github.com/inlets/inletsctl/pkg/provision/gce.go
+++ b/vendor/github.com/inlets/inletsctl/pkg/provision/gce.go
@@ -32,7 +32,7 @@ func (gce *GCEProvisioner) Provision(host BasicHost) (*ProvisionedHost, error) {
 		Description:  "Exit node created by inlets-operator",
 		MachineType:  fmt.Sprintf("zones/%s/machineTypes/%s", host.Additional["zone"], host.Plan),
 		CanIpForward: true,
-		Zone:         fmt.Sprintf("projects/%s/zones/us-central1-a", host.Additional["projectid"]),
+		Zone:         fmt.Sprintf("projects/%s/zones/%s", host.Additional["projectid"], host.Additional["zone"]),
 		Disks: []*compute.AttachedDisk{
 			{
 				AutoDelete: true,


### PR DESCRIPTION
Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [ ] I have raised an issue to propose this change.

## Description
Fix Google Compute Engine link. I guess this crept in while I was merging branches.
The fix will also ensure that we are not using the hardcoded zone for GCE exit node by updating the vendor dependency.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not needed

## How are existing users impacted? What migration steps/scripts do we need?
No user impact

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
