### PR TITLE
Fixes inlets-pro binary link

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -860,9 +860,9 @@ curl -sLO https://raw.githubusercontent.com/inlets/inlets/master/hack/inlets-ope
 export AUTHTOKEN="` + authToken + `"
 export REMOTETCP="` + remoteTCP + `"
 export IP=$(curl -sfSL https://api.ipify.org)
-curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.0/inlets-pro-linux > inlets-pro-linux && \
-chmod +x ./inlets-pro-linux  && \
-mv ./inlets-pro-linux /usr/local/bin/inlets-pro
+curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > /tmp/inlets-pro && \
+chmod +x /tmp/inlets-pro && \
+mv /tmp/inlets-pro /usr/local/bin/inlets-pro
 curl -sLO https://raw.githubusercontent.com/inlets/inlets/master/hack/inlets-pro.service  && \
 	mv inlets-pro.service /etc/systemd/system/inlets-pro.service && \
 	echo "AUTHTOKEN=$AUTHTOKEN" >> /etc/default/inlets-pro && \


### PR DESCRIPTION
The bad link was giving 404s. This commit fixes it for
inlets-operator. Thanks to @alexellis and @Waterdrips

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [ ] I have raised an issue to propose this change.

## Description
The bad link was giving 404s. This commit fixes it for 
inlets-operator. Thanks to @alexellis and @Waterdrips


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<img width="948" alt="Screenshot 2020-01-10 at 12 41 18 AM" src="https://user-images.githubusercontent.com/25264581/72097265-fedcde80-3341-11ea-8ef7-ab58dabe36d2.png">
<img width="852" alt="Screenshot 2020-01-10 at 12 38 37 AM" src="https://user-images.githubusercontent.com/25264581/72097274-0603ec80-3342-11ea-9019-751bf3635b64.png">



## How are existing users impacted? What migration steps/scripts do we need?
No user impact

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
