### PR TITLE
Reduce the verbosity of the log

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -98,7 +98,7 @@ func NewController(
 	utilruntime.Must(inletsscheme.AddToScheme(scheme.Scheme))
 	klog.V(4).Info("Creating event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartLogging(klog.V(4).Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [ ] I have raised an issue to propose this change.

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested on k3s cluster on my raspberry Pi using `k3sup`

Log before the change:
```
020/02/06 19:15:34 Inlets client: inlets/inlets:2.6.4
2020/02/06 19:15:34 Inlets pro: false
W0206 19:15:34.598622       1 client_config.go:543] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0206 19:15:34.604056       1 controller.go:118] Setting up event handlers
I0206 19:15:34.604178       1 controller.go:235] Starting Tunnel controller
I0206 19:15:34.604202       1 controller.go:238] Waiting for informer caches to sync
I0206 19:15:34.704506       1 controller.go:243] Starting workers
I0206 19:15:34.704854       1 controller.go:249] Started workers
I0206 19:15:34.705125       1 controller.go:307] Successfully synced 'default/kubernetes'
I0206 19:15:34.710295       1 controller.go:307] Successfully synced 'kube-system/metrics-server'
I0206 19:15:34.710429       1 controller.go:307] Successfully synced 'openfaas-fn/figlet'
I0206 19:15:34.710517       1 controller.go:307] Successfully synced 'openfaas/prometheus'
I0206 19:15:34.710641       1 controller.go:307] Successfully synced 'openfaas/basic-auth-plugin'
I0206 19:15:34.710723       1 controller.go:307] Successfully synced 'kube-system/kube-dns'
I0206 19:15:34.710807       1 controller.go:307] Successfully synced 'kube-system/traefik-prometheus'
I0206 19:15:34.710923       1 controller.go:307] Successfully synced 'openfaas/alertmanager'
I0206 19:15:34.711010       1 controller.go:307] Successfully synced 'openfaas/gateway-external'
I0206 19:15:34.711097       1 controller.go:307] Successfully synced 'openfaas/gateway'
I0206 19:15:34.711184       1 controller.go:307] Successfully synced 'openfaas/nats'
2020/02/06 19:15:34 Creating tunnel for traefik-tunnel.kube-system
I0206 19:15:34.811987       1 controller.go:307] Successfully synced 'kube-system/traefik'
2020/02/06 19:15:34 Provisioning host with DigitalOcean
2020/02/06 19:15:37 Provisioning call took: 2.750035s
2020/02/06 19:15:37 Status (traefik): provisioning, ID: 179098485, IP:
I0206 19:15:37.574942       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:15:37.575045       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4462", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:15:38.166044       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:15:38.166320       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4468", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
2020/02/06 19:16:04 Tunnel exists: traefik-tunnel
I0206 19:16:04.679381       1 controller.go:307] Successfully synced 'kube-system/traefik'
I0206 19:16:04.679514       1 controller.go:307] Successfully synced 'openfaas-fn/figlet'
I0206 19:16:04.679730       1 controller.go:307] Successfully synced 'openfaas/basic-auth-plugin'
I0206 19:16:04.679844       1 controller.go:307] Successfully synced 'default/kubernetes'
I0206 19:16:04.679923       1 controller.go:307] Successfully synced 'openfaas/prometheus'
I0206 19:16:04.679996       1 controller.go:307] Successfully synced 'kube-system/kube-dns'
I0206 19:16:04.680075       1 controller.go:307] Successfully synced 'kube-system/traefik-prometheus'
I0206 19:16:04.680146       1 controller.go:307] Successfully synced 'openfaas/alertmanager'
I0206 19:16:04.680235       1 controller.go:307] Successfully synced 'openfaas/gateway-external'
I0206 19:16:04.680334       1 controller.go:307] Successfully synced 'openfaas/gateway'
I0206 19:16:04.680416       1 controller.go:307] Successfully synced 'openfaas/nats'
I0206 19:16:04.680488       1 controller.go:307] Successfully synced 'kube-system/metrics-server'
I0206 19:16:05.786643       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:05.786725       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4468", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:16:34.658867       1 controller.go:307] Successfully synced 'openfaas/prometheus'
I0206 19:16:34.658997       1 controller.go:307] Successfully synced 'kube-system/kube-dns'
I0206 19:16:34.659083       1 controller.go:307] Successfully synced 'kube-system/traefik-prometheus'
I0206 19:16:34.659177       1 controller.go:307] Successfully synced 'openfaas/alertmanager'
I0206 19:16:34.659256       1 controller.go:307] Successfully synced 'openfaas/gateway-external'
I0206 19:16:34.659324       1 controller.go:307] Successfully synced 'openfaas/gateway'
I0206 19:16:34.659417       1 controller.go:307] Successfully synced 'openfaas/nats'
I0206 19:16:34.659491       1 controller.go:307] Successfully synced 'kube-system/metrics-server'
2020/02/06 19:16:34 Tunnel exists: traefik-tunnel
I0206 19:16:34.683535       1 controller.go:307] Successfully synced 'kube-system/traefik'
I0206 19:16:34.683626       1 controller.go:307] Successfully synced 'openfaas-fn/figlet'
I0206 19:16:34.683715       1 controller.go:307] Successfully synced 'openfaas/basic-auth-plugin'
I0206 19:16:34.683799       1 controller.go:307] Successfully synced 'default/kubernetes'
2020/02/06 19:16:35 Status (traefik): active, ID: 179098485, IP: 206.189.134.46
I0206 19:16:35.782512       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:35.784029       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4468", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
2020/02/06 19:16:35 Tunnel exists: traefik-tunnel
I0206 19:16:35.874825       1 controller.go:307] Successfully synced 'kube-system/traefik'
I0206 19:16:35.921410       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:35.921522       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:35.921975       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4513", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:16:35.922058       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4513", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:16:35.927418       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:35.927514       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4519", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:16:36.078707       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:36.078791       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4519", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:16:36.144495       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:36.144596       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4519", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:16:36.360435       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:36.360529       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4519", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:16:50.914993       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:16:50.915279       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4519", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:17:04.650660       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 19:17:04.652551       1 event.go:281] Event(v1.ObjectReference{Kind:"Tunnel", Namespace:"kube-system", Name:"traefik-tunnel", UID:"da99ec26-58ec-4223-ba81-35e183115217", APIVersion:"inlets.inlets.dev/v1alpha1", ResourceVersion:"4519", FieldPath:""}): type: 'Normal' reason: 'Synced' Tunnel synced successfully
I0206 19:17:04.660208       1 controller.go:307] Successfully synced 'openfaas/gateway-external'
I0206 19:17:04.660356       1 controller.go:307] Successfully synced 'openfaas/gateway'
I0206 19:17:04.660462       1 controller.go:307] Successfully synced 'openfaas/nats'
I0206 19:17:04.660551       1 controller.go:307] Successfully synced 'kube-system/metrics-server'
I0206 19:17:04.660628       1 controller.go:307] Successfully synced 'openfaas/prometheus'
I0206 19:17:04.660699       1 controller.go:307] Successfully synced 'kube-system/kube-dns'
I0206 19:17:04.660775       1 controller.go:307] Successfully synced 'kube-system/traefik-prometheus'
I0206 19:17:04.660844       1 controller.go:307] Successfully synced 'openfaas/alertmanager'
I0206 19:17:04.660918       1 controller.go:307] Successfully synced 'default/kubernetes'
I0206 19:17:04.661494       1 controller.go:307] Successfully synced 'openfaas-fn/figlet'
I0206 19:17:04.661609       1 controller.go:307] Successfully synced 'openfaas/basic-auth-plugin'
2020/02/06 19:17:04 Tunnel exists: traefik-tunnel
```

Log after change:
```
kubectl logs deploy/inlets-operator -f
Found 2 pods, using pod/inlets-operator-6fc48549fd-sw49n
2020/02/06 20:04:08 Inlets client: inlets/inlets:2.6.4
2020/02/06 20:04:08 Inlets pro: false
W0206 20:04:08.507828       1 client_config.go:543] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0206 20:04:08.522410       1 controller.go:118] Setting up event handlers
I0206 20:04:08.522818       1 controller.go:235] Starting Tunnel controller
I0206 20:04:08.522873       1 controller.go:238] Waiting for informer caches to sync
I0206 20:04:08.723312       1 controller.go:243] Starting workers
I0206 20:04:08.723422       1 controller.go:249] Started workers
I0206 20:04:08.723706       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 20:04:08.723744       1 controller.go:307] Successfully synced 'default/nginx-1-tunnel'
I0206 20:04:08.723823       1 controller.go:307] Successfully synced 'openfaas/gateway-external'
I0206 20:04:08.723860       1 controller.go:307] Successfully synced 'openfaas/gateway'
I0206 20:04:08.723924       1 controller.go:307] Successfully synced 'openfaas/nats'
I0206 20:04:08.723956       1 controller.go:307] Successfully synced 'openfaas/prometheus'
I0206 20:04:08.724011       1 controller.go:307] Successfully synced 'openfaas/alertmanager'
I0206 20:04:08.724069       1 controller.go:307] Successfully synced 'kube-system/kube-dns'
I0206 20:04:08.724019       1 controller.go:307] Successfully synced 'openfaas/basic-auth-plugin'
I0206 20:04:08.724124       1 controller.go:307] Successfully synced 'kube-system/traefik-prometheus'
I0206 20:04:08.724178       1 controller.go:307] Successfully synced 'openfaas-fn/figlet'
2020/02/06 20:04:08 Tunnel exists: nginx-1-tunnel
I0206 20:04:08.756089       1 controller.go:307] Successfully synced 'default/nginx-1'
I0206 20:04:08.756344       1 controller.go:307] Successfully synced 'default/kubernetes'
I0206 20:04:08.756595       1 controller.go:307] Successfully synced 'kube-system/metrics-server'
2020/02/06 20:04:08 Tunnel exists: traefik-tunnel
I0206 20:04:08.757538       1 controller.go:307] Successfully synced 'kube-system/traefik'
I0206 20:04:38.602660       1 controller.go:307] Successfully synced 'kube-system/traefik-tunnel'
I0206 20:04:38.602800       1 controller.go:307] Successfully synced 'default/nginx-1-tunnel'
I0206 20:04:38.608199       1 controller.go:307] Successfully synced 'openfaas/gateway-external'
I0206 20:04:38.608305       1 controller.go:307] Successfully synced 'openfaas/prometheus'
I0206 20:04:38.608741       1 controller.go:307] Successfully synced 'openfaas-fn/figlet'
I0206 20:04:38.608841       1 controller.go:307] Successfully synced 'kube-system/metrics-server'
I0206 20:04:38.608921       1 controller.go:307] Successfully synced 'openfaas/alertmanager'
I0206 20:04:38.608995       1 controller.go:307] Successfully synced 'openfaas/nats'
I0206 20:04:38.609069       1 controller.go:307] Successfully synced 'openfaas/basic-auth-plugin'
I0206 20:04:38.609142       1 controller.go:307] Successfully synced 'kube-system/kube-dns'
I0206 20:04:38.609214       1 controller.go:307] Successfully synced 'kube-system/traefik-prometheus'
2020/02/06 20:04:38 Tunnel exists: traefik-tunnel
I0206 20:04:38.643790       1 controller.go:307] Successfully synced 'kube-system/traefik'
I0206 20:04:38.643888       1 controller.go:307] Successfully synced 'default/kubernetes'
I0206 20:04:38.643975       1 controller.go:307] Successfully synced 'openfaas/gateway'
2020/02/06 20:04:38 Tunnel exists: nginx-1-tunnel
```


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
