### PR TITLE
Add support for providers that require a secret key to the Helm Chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /inlets-operator
+.idea/

--- a/README.md
+++ b/README.md
@@ -134,6 +134,50 @@ k3sup app install inlets-operator \
  --token-file $HOME/Downloads/do-access-token
 ```
 
+## Using a provider which requires an Access Key and Secret Key? (AWS EC2, Scaleway)
+
+These providers require an additional secret to be provided, this can be created like this:
+
+
+ 
+To install using `k3sup` you can pass the additional --secret-key-file arg
+
+```sh
+
+k3sup app install inlets-operator \
+ --provider ec2 \
+ --region eu-west-1 \
+ --token-file $HOME/Downloads/access-key \
+ --secret-key-file $HOME/Downloads/secret-access-key \
+ --license $(cat $HOME/inlets-pro-license.txt)
+
+```
+
+If you are installing manually, using the yaml files you will need to un-comment the sections indicated in the
+ `artifacts/operator.yaml` file
+
+```sh
+
+kubectl apply -f ./artifacts/crd.yaml
+
+# Create a secret to store the access token
+
+kubectl create secret generic inlets-access-key \
+  --from-literal inlets-access-key="$(cat ~/Downloads/access-key)"
+
+# Create a secret to store the secret access token
+
+kubectl create secret generic inlets-secret-key \
+  --from-literal inlets-secret-key="$(cat ~/Downloads/secret-access-key)"
+
+kubectl apply -f ./artifacts/crd.yaml
+
+# Apply the operator deployment and RBAC role
+kubectl apply -f ./artifacts/operator-rbac.yaml
+kubectl apply -f ./artifacts/operator.yaml
+```
+ 
+
 ## Running in-cluster, using Google Compute Engine for the exit node using helm
 
 > Note: this example is now multi-arch, so it's valid for `x86_64`, `ARMHF`, and `ARM64`.

--- a/artifacts/operator.yaml
+++ b/artifacts/operator.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: inlets-operator
       containers:
       - name: operator
-        image: inlets/inlets-operator:0.4.4
+        image: inlets/inlets-operator:0.6.3
         imagePullPolicy: Always
         command:
           - ./inlets-operator
@@ -30,10 +30,15 @@ spec:
           # For Packet users
           # - "-provider=packet"
           # For inlets-pro
-          # - "-license=JWT-OBTAINED-FROM-https://github.com/inlets/inlets-pro"
+          # - "-license=<SET THIS TO YOUR LICENSE>"
+          #- "-pro-client-image=inlets/inlets-pro:0.5.1"
+          # For Providers that use an access key and a secret key
+          # - "-secret-key-file=/var/secrets/inlets/secret/inlets-secret-key"
+          # For providers that need a region
+          # - "-region=eu-west-1"
         env:
         - name: client_image
-          value: inlets/inlets:2.6.3
+          value: inlets/inlets:2.6.4
         resources:
           limits:
             memory: 128Mi
@@ -43,8 +48,17 @@ spec:
         - mountPath: /var/secrets/inlets/
           name: inlets-access-key
           readOnly: true
+        # For Providers that use an access key and a secret key
+        #- mountPath: /var/secrets/inlets/secret/
+        #  name: inlets-secret-key
+        #  readOnly: true
       volumes:
       - name: inlets-access-key
         secret:
           defaultMode: 420
           secretName: inlets-access-key
+      # For Providers that use an access key and a secret key
+      #- name: inlets-secret-key
+      #  secret:
+      #    defaultMode: 420
+      #    secretName: inlets-secret-key

--- a/chart/inlets-operator/Chart.yaml
+++ b/chart/inlets-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: inlets-operator for Kubernetes
 name: inlets-operator
-version: 0.6.4
+version: 0.6.5
 keywords:
 - networking
 - tunnels

--- a/chart/inlets-operator/README.md
+++ b/chart/inlets-operator/README.md
@@ -102,3 +102,4 @@ Parameter | Description | Default
 `nodeSelector`          | Node labels for data pod assignment                                             | `{}`
 `tolerations`           | Node tolerations                                                                | `[]`
 `affinity`              | Node affinity policy                                                            | `{}`
+`secretKeyFile`         | If we are using a provider that requires a secret key as well as an access key, set to `/var/secrets/inlets/secret/inlets-secret-key` | `""`

--- a/chart/inlets-operator/templates/deployment.yaml
+++ b/chart/inlets-operator/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         {{- if .Values.proClientImage }}
         - "-pro-client-image={{.Values.proClientImage}}"
         {{- end }}
+        {{- if .Values.secretKeyFile }}
+        - "-secret-key-file=/var/secrets/inlets/secret/inlets-secret-key"
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         env:
@@ -50,11 +53,22 @@ spec:
         - mountPath: /var/secrets/inlets/
           name: inlets-access-key
           readOnly: true
+        {{- if .Values.secretKeyFile }}
+        - mountPath: /var/secrets/inlets/secret/
+          name: inlets-secret-key
+          readOnly: true
+        {{- end }}
       volumes:
       - name: inlets-access-key
         secret:
           defaultMode: 420
           secretName: inlets-access-key
+      {{- if .Values.secretKeyFile }}
+      - name: inlets-secret-key
+        secret:
+          defaultMode: 420
+          secretName: inlets-secret-key
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/inlets-operator/values.yaml
+++ b/chart/inlets-operator/values.yaml
@@ -17,6 +17,9 @@ region: "lon1"
 
 accessKeyFile: "/var/secrets/inlets/inlets-access-key"
 
+# Set to /var/secrets/inlets/secret/inlets-secret-key for a provider that requires an access key and secret key, such as EC2
+secretKeyFile: ""
+
 # Obtain a free 14-day trial from https://github.com/inlets/inlets-pro
 inletsProLicense: ""
 


### PR DESCRIPTION
## Description
There was a case where a provider which required a secret key as well
as an access key couldn't pass the secret key into the inlets chart.


## How Has This Been Tested?

This has been added. And tested by using the new chart to install
inlets-operator on k3d clusters, once with EC2 provider, once with
Digital Ocean provider. Both k3d clusters created the relevant exit
nodes and forwarded traffic, EC2 was setup once with normal inlets,
once with inlets pro

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [x] I have raised an issue to propose this change.
fixes #54 
## How are existing users impacted? What migration steps/scripts do we need?
Existing users, no change.
Users wishing to use the chart with EC2 or scaleway providers can now pass the secret key to the chart.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
