### PR TITLE
Set requests/limits for the tunnel clients

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ type InfraConfig struct {
 	InletsClientImage string
 	AnnotatedOnly     bool
 	ProConfig         InletsProConfig
+	MaxClientMemory   string
 }
 
 func (i InfraConfig) UsePro() bool {
@@ -77,6 +78,7 @@ func main() {
 	flag.StringVar(&infra.ProjectID, "project-id", "", "The project ID if using Packet.com, or Google Compute Engine as the provider")
 	flag.StringVar(&infra.ProConfig.License, "license", "", "Supply a license for use with inlets-pro")
 	flag.StringVar(&infra.ProConfig.ClientImage, "pro-client-image", "", "Supply a Docker image for the inlets-pro client")
+	flag.StringVar(&infra.MaxClientMemory, "max-client-memory", "128Mi", "Maximum memory limit for the tunnel clients")
 
 	flag.BoolVar(&infra.AnnotatedOnly, "annotated-only", false, "Only create a tunnel for annotated services. Annotate with dev.inlets.manage=true.")
 

--- a/validate.go
+++ b/validate.go
@@ -1,6 +1,10 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 func validateFlags(c InfraConfig) error {
 	if c.Provider == "packet" {
@@ -16,5 +20,11 @@ func validateFlags(c InfraConfig) error {
 			return fmt.Errorf("zone required for provider: %s", c.Provider)
 		}
 	}
+	if len(c.MaxClientMemory) > 0 {
+		if _, err := resource.ParseQuantity(c.MaxClientMemory); err != nil {
+			return fmt.Errorf("invalid memory value: %s", err.Error())
+		}
+	}
+
 	return nil
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,6 +1,8 @@
 package main
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_validateFlags_DO(t *testing.T) {
 	c := InfraConfig{
@@ -50,5 +52,46 @@ func Test_validateFlags_GCE_ProjectID(t *testing.T) {
 	want := "project-id required for provider: gce"
 	if err.Error() != want {
 		t.Errorf("expected error: %s, got: %s", want, err)
+	}
+}
+
+func Test_validateFlags_BadMemoryValue(t *testing.T) {
+	c := InfraConfig{
+		Provider:        "digitalocean",
+		MaxClientMemory: "hundred",
+	}
+
+	err := validateFlags(c)
+	want := "invalid memory value: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"
+	if err == nil {
+		t.Errorf("expected an error with bad memory format")
+		return
+	}
+	if err.Error() != want {
+		t.Errorf("expected error: %q, got: %q", want, err)
+	}
+}
+
+func Test_validateFlags_GoodMemoryValue(t *testing.T) {
+	c := InfraConfig{
+		Provider:        "digitalocean",
+		MaxClientMemory: "100Mi",
+	}
+
+	err := validateFlags(c)
+	if err != nil {
+		t.Errorf("expected no error, got: %s", err.Error())
+	}
+}
+
+func Test_validateFlags_EmptyMemoryValue(t *testing.T) {
+	c := InfraConfig{
+		Provider:        "digitalocean",
+		MaxClientMemory: "",
+	}
+
+	err := validateFlags(c)
+	if err != nil {
+		t.Errorf("expected no error, got: %s", err.Error())
 	}
 }


### PR DESCRIPTION
Limits help prevent bad things from happening. CPU limits can
cause some unexpected behaviour, so this is not being added.

The --max-client-memory flag allows for the limit to be set
higher if required.

Fixes: #64

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
