### PR TITLE
Is this supposed to say 'pod'?

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ helm upgrade inlets-operator --install inlets/inlets-operator \
 kubectl run nginx-1 --image=nginx --port=80 --restart=Always
 kubectl run nginx-2 --image=nginx --port=80 --restart=Always
 
-kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer
-kubectl expose deployment nginx-2 --port=80 --type=LoadBalancer
+kubectl expose pod nginx-1 --port=80 --type=LoadBalancer
+kubectl expose pod nginx-2 --port=80 --type=LoadBalancer
 
 kubectl get svc
 


### PR DESCRIPTION
I'm very new to Kubernetes so it's quite likely I'm misunderstanding something, but running these two commands yields an error:
```
❯ kubectl run nginx-1 --image=nginx --port=80 --restart=Always
...
❯ kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer
Error from server (NotFound): deployments.apps "nginx-1" not found
```
When I changed `deployment` to `pod` I was able to expose my service:

```
❯ kubectl expose pod nginx-1 --port=80 --type=LoadBalancer
service/nginx-1 exposed
```

This is a documentation change so perhaps your contribution guidelines are less relevant?

If not feel free to close and proceed with your usual process.

<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [ ] I have raised an issue to propose this change.

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
