### PR TITLE
Optimize docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,14 @@ FROM golang:1.13 as builder
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 
-COPY --from=license-check /license-check /usr/bin/
-
-RUN mkdir -p /go/src/github.com/inlets/inlets-operator
 WORKDIR /go/src/github.com/inlets/inlets-operator
-
-RUN addgroup --system app && \
-  adduser --system --ingroup app app && \
-  mkdir /scratch-tmp
 
 # Cache the download before continuing
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
+
+COPY --from=license-check /license-check /usr/bin/
 
 COPY . .
 
@@ -32,17 +27,13 @@ RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags 
   -X github.com/inlets/inlets-operator/pkg/version.SHA=${GIT_COMMIT}" \
   -a -installsuffix cgo -o inlets-operator .
 
-# we can't add user in next stage because it's from scratch
-# ca-certificates and tmp folder are also missing in scratch
-# so we add all of it here and copy files in next stage
+# Use distroless as minimal base image to package the binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
 
-FROM scratch
+WORKDIR /
 
-COPY --from=builder /etc/passwd /etc/group /etc/
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder --chown=app:app /scratch-tmp /tmp/
-COPY --from=builder /go/src/github.com/inlets/inlets-operator/inlets-operator .
+COPY --from=builder /go/src/github.com/inlets/inlets-operator/inlets-operator /
+USER nonroot:nonroot
 
-USER app
-
-CMD ["./inlets-operator"]
+CMD ["/inlets-operator"]


### PR DESCRIPTION
<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [ ] I have raised an issue to propose this change.

## Description

Optimize the build of the docker image caching go modules and using `gcr.io/distroless/static:nonroot` as base image

## How Has This Been Tested?

Using `make build` dependencies are downloaded once, and the cache is used afterward.

## How are existing users impacted? What migration steps/scripts do we need?

No impact or migration.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
