### PR TITLE
Fix issue with status sub-resource (#84)

### DIFF
--- a/artifacts/crds/inlets.inlets.dev_tunnels.yaml
+++ b/artifacts/crds/inlets.inlets.dev_tunnels.yaml
@@ -1,10 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: tunnels.inlets.inlets.dev
 spec:
@@ -36,6 +34,7 @@ spec:
   validation:
     openAPIV3Schema:
       description: Tunnel is a specification for a Tunnel resource
+      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -51,17 +50,18 @@ spec:
           type: object
         spec:
           description: TunnelSpec is the spec for a Tunnel resource
+          type: object
           properties:
             auth_token:
               type: string
             client_deployment:
-              nullable: true
               type: object
+              nullable: true
             serviceName:
               type: string
-          type: object
         status:
           description: TunnelStatus is the status for a Tunnel resource
+          type: object
           properties:
             hostIP:
               type: string
@@ -69,12 +69,6 @@ spec:
               type: string
             hostStatus:
               type: string
-          required:
-          - hostIP
-          - hostId
-          - hostStatus
-          type: object
-      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
@@ -84,8 +78,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-# This is not generated
-#  conditions: null
-#  storedVersions: null
   conditions: []
   storedVersions: []

--- a/controller.go
+++ b/controller.go
@@ -923,7 +923,7 @@ func (c *Controller) updateTunnelProvisioningStatus(tunnel *inletsv1alpha1.Tunne
 	tunnelCopy.Status.HostID = id
 	tunnelCopy.Status.HostIP = ip
 
-	_, err := c.operatorclientset.InletsV1alpha1().Tunnels(tunnel.Namespace).Update(tunnelCopy)
+	_, err := c.operatorclientset.InletsV1alpha1().Tunnels(tunnel.Namespace).UpdateStatus(tunnelCopy)
 	return err
 }
 

--- a/pkg/apis/inletsoperator/v1alpha1/types.go
+++ b/pkg/apis/inletsoperator/v1alpha1/types.go
@@ -52,9 +52,12 @@ type TunnelSpec struct {
 
 // TunnelStatus is the status for a Tunnel resource
 type TunnelStatus struct {
+	// + optional
 	HostStatus string `json:"hostStatus,omitempty"`
-	HostIP     string `json:"hostIP,omitempty"`
-	HostID     string `json:"hostId,omitempty"`
+	// + optional
+	HostIP string `json:"hostIP,omitempty"`
+	// + optional
+	HostID string `json:"hostId,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
After moving to a status sub-resource in the generated CRD
the status had to be updated via UpdateStatus() on the
Kubernetes clientset, not via Update() as we had it.

The CRD is also made so that its status fields are optional
so the status can be set whilst we have a hostID, but no
hostIP yet.

Requires a new release and helm chart version for the users to
receive this fix.

A big thank you to @munnerz for the hints on this.

Fixes: #84

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
