### PR TITLE
Migrate to inlets-pro 0.7.0

### DIFF
--- a/chart/inlets-operator/Chart.yaml
+++ b/chart/inlets-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: inlets-operator for Kubernetes
 name: inlets-operator
-version: 0.8.7
+version: 0.8.8
 keywords:
 - networking
 - tunnels

--- a/chart/inlets-operator/values.yaml
+++ b/chart/inlets-operator/values.yaml
@@ -30,8 +30,8 @@ annotatedOnly: false
 
 image: "inlets/inlets-operator:0.8.6"
 pullPolicy: "IfNotPresent"
-clientImage: "inlets/inlets:2.7.3"
-proClientImage: "inlets/inlets-pro:0.6.0"
+clientImage: "inlets/inlets:2.7.4"
+proClientImage: "inlets/inlets-pro:0.7.0"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.27.3 // indirect
-	github.com/inlets/inletsctl v0.0.0-20200827135227-594b78220d6e
+	github.com/inlets/inletsctl v0.0.0-20200827152430-ac28a1e46c51
+
 	github.com/sethvargo/go-password v0.2.0
 
 	k8s.io/api v0.18.3

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.27.3 // indirect
-	github.com/inlets/inletsctl v0.0.0-20200630123138-2af07d807845
-	github.com/sethvargo/go-password v0.1.3
+	github.com/inlets/inletsctl v0.0.0-20200827135227-594b78220d6e
+	github.com/sethvargo/go-password v0.2.0
 
 	k8s.io/api v0.18.3
 	k8s.io/apimachinery v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
@@ -148,6 +150,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hetznercloud/hcloud-go v1.18.2 h1:ZCDJHCqKqfT3SnZ+kESVqmqh8QgoTqjnddt7g3v5Yfs=
+github.com/hetznercloud/hcloud-go v1.18.2/go.mod h1:EhElojlVU1biA5JgBaV8rRU1vE5+iYke402kXC9pooE=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
@@ -155,6 +159,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inlets/inletsctl v0.0.0-20200630123138-2af07d807845 h1:kXLRUtZf8bxoFJwmiBvBWFgu06nkLXu3YbNpPHnIyUc=
 github.com/inlets/inletsctl v0.0.0-20200630123138-2af07d807845/go.mod h1:TYXLQgu6kEQAH+X2TgZclvJ1h+QK7cJaoPGfkfIr9KI=
+github.com/inlets/inletsctl v0.0.0-20200827135227-594b78220d6e h1:CoeGECUzZGIy++iHIhAiymPzJ7iEVBw6OIKR+liHlH0=
+github.com/inlets/inletsctl v0.0.0-20200827135227-594b78220d6e/go.mod h1:QJ7kj0pyEPAsdYWAdhfWfN5mErQ0Qp+7M3s4u//CMN4=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -209,6 +215,8 @@ github.com/scaleway/scaleway-sdk-go v1.0.0-beta.4 h1:k0j49IgEf+5j0vwqP8StW5gjzVN
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.4/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
 github.com/sethvargo/go-password v0.1.3 h1:18KkbGDkw8SuzeohAbWqBLNSfRQblVwEHOLbPa0PvWM=
 github.com/sethvargo/go-password v0.1.3/go.mod h1:2tyaaoHK/AlXwh5WWQDYjqQbHcq4cjPj5qb/ciYvu/Q=
+github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
+github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/go.sum
+++ b/go.sum
@@ -157,10 +157,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inlets/inletsctl v0.0.0-20200630123138-2af07d807845 h1:kXLRUtZf8bxoFJwmiBvBWFgu06nkLXu3YbNpPHnIyUc=
-github.com/inlets/inletsctl v0.0.0-20200630123138-2af07d807845/go.mod h1:TYXLQgu6kEQAH+X2TgZclvJ1h+QK7cJaoPGfkfIr9KI=
-github.com/inlets/inletsctl v0.0.0-20200827135227-594b78220d6e h1:CoeGECUzZGIy++iHIhAiymPzJ7iEVBw6OIKR+liHlH0=
-github.com/inlets/inletsctl v0.0.0-20200827135227-594b78220d6e/go.mod h1:QJ7kj0pyEPAsdYWAdhfWfN5mErQ0Qp+7M3s4u//CMN4=
+github.com/inlets/inletsctl v0.0.0-20200827152430-ac28a1e46c51 h1:5dAO9CtLwMtwjVpqQXNMiE5F8GVuxJ7uK9Fqsop/Dkc=
+github.com/inlets/inletsctl v0.0.0-20200827152430-ac28a1e46c51/go.mod h1:QJ7kj0pyEPAsdYWAdhfWfN5mErQ0Qp+7M3s4u//CMN4=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -310,6 +308,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9 h1:ZBzSG/7F4eNKz2L3GE9o300RX0Az1Bw5HF7PDraD+qU=
 golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/image_test.go
+++ b/image_test.go
@@ -6,7 +6,7 @@ func Test_GetInletsClientImage_DefaultOSSNoOverride(t *testing.T) {
 
 	c := InfraConfig{}
 	got := c.GetInletsClientImage()
-	want := "inlets/inlets:2.7.2"
+	want := "inlets/inlets:2.7.4"
 	if got != want {
 		t.Errorf("for OSS variant want %s, but got %s", want, got)
 		t.Fail()
@@ -22,7 +22,7 @@ func Test_GetInletsClientImage_DefaultProNoOverride(t *testing.T) {
 	}
 
 	got := c.GetInletsClientImage()
-	want := "inlets/inlets-pro:0.6.0"
+	want := "inlets/inlets-pro:0.7.0"
 	if got != want {
 		t.Errorf("for OSS variant want %s, but got %s", want, got)
 		t.Fail()


### PR DESCRIPTION
## Description

Migrate to inlets-pro 0.7.0

## How Has This Been Tested?

Unit tests, within inletsctl and through manual e2e testing with DigitalOcean

Created a PRO exit-server by installing and exposing Nginx

```bash
arkade install inlets-operator \
  --set proClientImage=inlets/inlets-pro:0.7.0 \
  --license-file ~/LICENSE \
  --token-file ~/Downloads/do-access-token \
  --set image=inlets/inlets-operator:0.8.7-rc1-amd64 \
  --set clientImage=inlets/inlets:2.7.4
```

## How are existing users impacted? What migration steps/scripts do we need?

This version will create new exit-servers and pods using the newer syntax. Older exit-servers may benefit from being removed and re-created.
