### PR TITLE
Bump up to using buildx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,39 @@
 sudo: required
 language: go
 
+dist: bionic
+
 go:
 - "1.13"
 
-services:
-- docker
-
 script:
-- TAG=${TRAVIS_TAG:=latest} make build
+- docker buildx version
+- TAG=${TRAVIS_TAG:=latest} make docker
+
+before_script:
+  - sudo rm -rf /var/lib/apt/lists/*
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+  - sudo apt-get update -qy
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - mkdir -vp ~/.docker/cli-plugins/
+  - curl --silent -L "https://github.com/docker/buildx/releases/download/v0.3.0/buildx-v0.3.0.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+  - chmod a+x ~/.docker/cli-plugins/docker-buildx
+  - sudo systemctl start docker
+  - ./hack/install-buildx.sh
+
+after_success:
+  - make docker-login
+  - make docker-login-ghcr
+  - make push
+  - make push-ghcr
+script:
 
 before_deploy:
 - echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 
 deploy:
   provider: script
-  script: TAG=${TRAVIS_TAG} make push manifest
+  script: TAG=${TRAVIS_TAG} make docker-login docker-login-ghcr push push-ghcr
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,7 @@ script:
 - TAG=${TRAVIS_TAG:=latest} make docker
 
 before_script:
-  - sudo rm -rf /var/lib/apt/lists/*
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
-  - sudo apt-get update -qy
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  - mkdir -vp ~/.docker/cli-plugins/
-  - curl --silent -L "https://github.com/docker/buildx/releases/download/v0.3.0/buildx-v0.3.0.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
-  - chmod a+x ~/.docker/cli-plugins/docker-buildx
-  - sudo systemctl start docker
+  - ./hack/install-docker.sh
   - ./hack/install-buildx.sh
 
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM teamserverless/license-check:0.3.6 as license-check
+FROM teamserverless/license-check:0.3.9 as license-check
 
 FROM golang:1.13 as builder
 ENV CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,16 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 .PHONY: all
 all: build
 
+.PHONY: build-local
+build-local:
+	@docker buildx create --use --name=multiarch --node multiarch && \
+	docker buildx build \
+		--progress=plain \
+		--build-arg VERSION=$(Version) --build-arg GIT_COMMIT=$(GitCommit) \
+		--platform linux/amd64 \
+		--output "type=docker,push=false" \
+		--tag inlets/inlets-operator:$(TAG) .
+
 .PHONY: build
 build:
 	@docker buildx create --use --name=multiarch --node multiarch && \
@@ -35,7 +45,7 @@ push:
 	docker buildx build \
 		--progress=plain \
 		--build-arg VERSION=$(Version) --build-arg GIT_COMMIT=$(GitCommit) \
-		--platform linux/amd64,true/arm/v6,linux/arm64 \
+		--platform linux/amd64,linux/arm/v6,linux/arm64 \
 		--output "type=image,push=true" \
 		--tag inlets/inlets-operator:$(TAG) .
 

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,53 @@
 .PHONY: build push manifest test verify-codegen charts
 TAG?=latest
 
+Version := $(shell git describe --tags --dirty)
+GitCommit := $(shell git rev-parse HEAD)
+
 # docker manifest command will work with Docker CLI 18.03 or newer
 # but for now it's still experimental feature so we need to enable that
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
+.PHONY: all
+all: build
+
+.PHONY: build
 build:
-	docker build -t inlets/inlets-operator:$(TAG)-amd64 . -f Dockerfile
-	docker build --build-arg OPTS="GOARCH=arm64" -t inlets/inlets-operator:$(TAG)-arm64 . -f Dockerfile
-	docker build --build-arg OPTS="GOARCH=arm GOARM=6" -t inlets/inlets-operator:$(TAG)-armhf . -f Dockerfile
+	@docker buildx create --use --name=multiarch --node multiarch && \
+	docker buildx build \
+		--progress=plain \
+		--build-arg VERSION=$(Version) --build-arg GIT_COMMIT=$(GitCommit) \
+		--platform linux/amd64,linux/arm/v6,linux/arm64 \
+		--output "type=image,push=false" \
+		--tag inlets/inlets-operator:$(TAG) .
 
+.PHONY: docker-login
+docker-login:
+	echo -n "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+
+.PHONY: docker-login-ghcr
+docker-login-ghcr:
+	echo -n "${GHCR_PASSWORD}" | docker login -u "${GHCR_USERNAME}" --password-stdin ghcr.io
+
+.PHONY: push
 push:
-	docker push inlets/inlets-operator:$(TAG)-amd64
-	docker push inlets/inlets-operator:$(TAG)-arm64
-	docker push inlets/inlets-operator:$(TAG)-armhf
+	@docker buildx create --use --name=multiarch --node multiarch && \
+	docker buildx build \
+		--progress=plain \
+		--build-arg VERSION=$(Version) --build-arg GIT_COMMIT=$(GitCommit) \
+		--platform linux/amd64,true/arm/v6,linux/arm64 \
+		--output "type=image,push=true" \
+		--tag inlets/inlets-operator:$(TAG) .
 
-manifest:
-	docker manifest create --amend inlets/inlets-operator:$(TAG) \
-		inlets/inlets-operator:$(TAG)-amd64 \
-		inlets/inlets-operator:$(TAG)-arm64 \
-		inlets/inlets-operator:$(TAG)-armhf
-	docker manifest annotate inlets/inlets-operator:$(TAG) inlets/inlets-operator:$(TAG)-arm64 --os linux --arch arm64
-	docker manifest annotate inlets/inlets-operator:$(TAG) inlets/inlets-operator:$(TAG)-armhf --os linux --arch arm --variant v6
-	docker manifest push -p inlets/inlets-operator:$(TAG)
+.PHONY: push-ghcr
+push-ghcr:
+	@docker buildx create --use --name=multiarch --node multiarch && \
+	docker buildx build \
+		--progress=plain \
+		--build-arg VERSION=$(Version) --build-arg GIT_COMMIT=$(GitCommit) \
+		--platform linux/amd64,linux/arm/v6,linux/arm64 \
+		--output "type=image,push=true" \
+		--tag ghcr.io/inlets/inlets-operator:$(TAG) .
 
 test:
 	go test ./...
@@ -34,4 +59,3 @@ charts:
 	cd chart && helm package inlets-operator/
 	mv chart/*.tgz docs/
 	helm repo index docs --url https://inlets.github.io/inlets-operator/ --merge ./docs/index.yaml
-

--- a/hack/install-buildx.sh
+++ b/hack/install-buildx.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+if [ -n "$DEBUG" ]; then
+	set -x
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+if ! docker buildx 2>&1 >/dev/null; then
+  echo "buildx not available. Docker 19.03 or higher is required with experimental features enabled"
+  exit 1
+fi
+
+# We can skip setup if the current builder already has multi-arch
+# AND if it isn't the docker driver, which doesn't work
+current_builder="$(docker buildx inspect)"
+# linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
+if ! grep -q "^Driver: docker$"  <<<"${current_builder}" && \
+     grep -q "linux/amd64" <<<"${current_builder}" && \
+     grep -q "linux/arm"   <<<"${current_builder}" && \
+     grep -q "linux/arm64" <<<"${current_builder}"; then
+  exit 0
+fi
+
+# Ensure qemu is in binfmt_misc
+# Docker desktop already has these in versions recent enough to have buildx
+# We only need to do this setup on linux hosts
+if [ "$(uname)" == 'Linux' ]; then
+  # NOTE: this is pinned to a digest for a reason!
+  docker run --rm --privileged multiarch/qemu-user-static@sha256:28ebe2e48220ae8fd5d04bb2c847293b24d7fbfad84f0b970246e0a4efd48ad6 --reset -p yes
+fi
+
+# Ensure we use a builder that can leverage it (the default on linux will not)
+docker buildx create --use --name=multiarch --node multiarch

--- a/hack/install-docker.sh
+++ b/hack/install-docker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Source: https://www.docker.com/blog/multi-arch-build-what-about-travis/
+
+sudo rm -rf /var/lib/apt/lists/*
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+sudo apt-get update -qy
+sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+mkdir -vp ~/.docker/cli-plugins/
+curl --silent -L "https://github.com/docker/buildx/releases/download/v0.3.0/buildx-v0.3.0.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+chmod a+x ~/.docker/cli-plugins/docker-buildx
+sudo systemctl start docker
+


### PR DESCRIPTION
buildx is the more modern approach to multi-arch from Docker.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [ ] I have raised an issue to propose this change.

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
