### PR TITLE
Update CRD api group to v1

### DIFF
--- a/artifacts/crds/inlets.inlets.dev_tunnels.yaml
+++ b/artifacts/crds/inlets.inlets.dev_tunnels.yaml
@@ -1,27 +1,11 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: tunnels.inlets.inlets.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.serviceName
-    name: Service
-    type: string
-  - JSONPath: .spec.client_deployment.name
-    name: Tunnel
-    type: string
-  - JSONPath: .status.hostStatus
-    name: HostStatus
-    type: string
-  - JSONPath: .status.hostIP
-    name: HostIP
-    type: string
-  - JSONPath: .status.hostId
-    name: HostID
-    type: string
   group: inlets.inlets.dev
   names:
     kind: Tunnel
@@ -29,51 +13,66 @@ spec:
     plural: tunnels
     singular: tunnel
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Tunnel is a specification for a Tunnel resource
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TunnelSpec is the spec for a Tunnel resource
-          type: object
-          properties:
-            auth_token:
-              type: string
-            client_deployment:
-              type: object
-              nullable: true
-            serviceName:
-              type: string
-        status:
-          description: TunnelStatus is the status for a Tunnel resource
-          type: object
-          properties:
-            hostIP:
-              type: string
-            hostId:
-              type: string
-            hostStatus:
-              type: string
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.serviceName
+      name: Service
+      type: string
+    - jsonPath: .spec.client_deployment.name
+      name: Tunnel
+      type: string
+    - jsonPath: .status.hostStatus
+      name: HostStatus
+      type: string
+    - jsonPath: .status.hostIP
+      name: HostIP
+      type: string
+    - jsonPath: .status.hostId
+      name: HostID
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Tunnel is a specification for a Tunnel resource
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TunnelSpec is the spec for a Tunnel resource
+            type: object
+            properties:
+              auth_token:
+                type: string
+              client_deployment:
+                type: object
+                nullable: true
+              serviceName:
+                type: string
+          status:
+            description: TunnelStatus is the status for a Tunnel resource
+            type: object
+            properties:
+              hostIP:
+                type: string
+              hostId:
+                type: string
+              hostStatus:
+                type: string
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/chart/inlets-operator/README.md
+++ b/chart/inlets-operator/README.md
@@ -25,7 +25,7 @@ You can also install the inlets-operator with [arkade install inlets-operator](h
     ```
 
 * Install the CRD:
-
+    Requires Kubernetes 1.16+
     ```sh
     kubectl apply -f ./artifacts/crds
     ```

--- a/hack/update-crds.sh
+++ b/hack/update-crds.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 export controllergen="$GOPATH/bin/controller-gen"
-export PKG=sigs.k8s.io/controller-tools/cmd/controller-gen
+export PKG=sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0
 
-if [ ! -e "$gen" ]
+if [ ! -e "$controllergen" ]
 then
 echo "Getting $PKG"
-    GO111MODULE=off go get $PKG
+    go install $PKG
 fi
 
 echo $controllergen
 
-echo "$controllergen" \
+"$controllergen" \
   crd \
   schemapatch:manifests=./artifacts/crds \
   paths=./pkg/apis/... \
@@ -19,8 +19,8 @@ echo "$controllergen" \
 
 # Some versions of controller-tools generate storedVersions and conditions as null,
 # We need to change them to []
-echo sed -i.bak \
+sed -i.bak \
   -e 's/conditions: null/conditions: \[\]/' \
   -e 's/storedVersions: null/storedVersions: \[\]/' \
   ./artifacts/crds/*.yaml
-echo rm -f ./artifacts/crds/*.bak
+rm -f ./artifacts/crds/*.bak


### PR DESCRIPTION
<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [x] I have raised an issue to propose this change.

Related to openfaas/faas-netes#709

## Description

- Update the CRD definition schema to use the v1 API. The beta API is
  being deprecated and will be removed in v1.19 (which is coming soon)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```sh
$ kind create clsuter
$ kubectl apply -f ./artifacts/crds
customresourcedefinition.apiextensions.k8s.io/tunnels.inlets.inlets.dev created
```


## How are existing users impacted? What migration steps/scripts do we need?
Users will need Kubernetes 1.16+
Users of earlier version will need to install from an earlier release.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
