### PR TITLE
Return errors from provisioner factories

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -137,7 +137,12 @@ func NewController(
 				log.Println("Status.HostID is empty")
 				return
 			}
-			provisioner, _ := getProvisioner(controller)
+			provisioner, err := getProvisioner(controller)
+			if err != nil {
+				log.Printf("Error creating provisioner: %s", err.Error())
+				return
+			}
+
 			if provisioner != nil {
 				log.Printf("Deleting exit-node for %s: %s, ip: %s\n", r.Spec.ServiceName, r.Status.HostID, r.Status.HostIP)
 
@@ -640,21 +645,21 @@ func getProvisioner(c *Controller) (provision.Provisioner, error) {
 
 	switch c.infraConfig.Provider {
 	case "equinix-metal":
-		provisioner, _ = provision.NewEquinixMetalProvisioner(c.infraConfig.GetAccessKey())
+		provisioner, err = provision.NewEquinixMetalProvisioner(c.infraConfig.GetAccessKey())
 	case "digitalocean":
-		provisioner, _ = provision.NewDigitalOceanProvisioner(c.infraConfig.GetAccessKey())
+		provisioner, err = provision.NewDigitalOceanProvisioner(c.infraConfig.GetAccessKey())
 	case "scaleway":
-		provisioner, _ = provision.NewScalewayProvisioner(c.infraConfig.GetAccessKey(), c.infraConfig.GetSecretKey(), c.infraConfig.OrganizationID, c.infraConfig.Region)
+		provisioner, err = provision.NewScalewayProvisioner(c.infraConfig.GetAccessKey(), c.infraConfig.GetSecretKey(), c.infraConfig.OrganizationID, c.infraConfig.Region)
 	case "gce":
-		provisioner, _ = provision.NewGCEProvisioner(c.infraConfig.GetAccessKey())
+		provisioner, err = provision.NewGCEProvisioner(c.infraConfig.GetAccessKey())
 	case "ec2":
-		provisioner, _ = provision.NewEC2Provisioner(c.infraConfig.Region, c.infraConfig.GetAccessKey(), c.infraConfig.GetSecretKey())
+		provisioner, err = provision.NewEC2Provisioner(c.infraConfig.Region, c.infraConfig.GetAccessKey(), c.infraConfig.GetSecretKey())
 	case "linode":
-		provisioner, _ = provision.NewLinodeProvisioner(c.infraConfig.GetAccessKey())
+		provisioner, err = provision.NewLinodeProvisioner(c.infraConfig.GetAccessKey())
 	case "azure":
-		provisioner, _ = provision.NewAzureProvisioner(c.infraConfig.SubscriptionID, c.infraConfig.GetAccessKey())
+		provisioner, err = provision.NewAzureProvisioner(c.infraConfig.SubscriptionID, c.infraConfig.GetAccessKey())
 	case "hetzner":
-		provisioner, _ = provision.NewHetznerProvisioner(c.infraConfig.GetAccessKey())
+		provisioner, err = provision.NewHetznerProvisioner(c.infraConfig.GetAccessKey())
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", c.infraConfig.Provider)
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -2,17 +2,6 @@ package main
 
 import "testing"
 
-func Test_GetInletsClientImage_DefaultOSSNoOverride(t *testing.T) {
-
-	c := InfraConfig{}
-	got := c.GetInletsClientImage()
-	want := "inlets/inlets:2.7.10"
-	if got != want {
-		t.Errorf("for OSS variant want %s, but got %s", want, got)
-		t.Fail()
-	}
-}
-
 func Test_GetInletsClientImage_DefaultProNoOverride(t *testing.T) {
 
 	c := InfraConfig{

--- a/main.go
+++ b/main.go
@@ -170,18 +170,10 @@ func main() {
 
 // GetInletsClientImage returns the image for the client-side tunnel
 func (i *InfraConfig) GetInletsClientImage() string {
-	if i.UsePro() {
-		if i.ProConfig.ClientImage == "" {
-			return "ghcr.io/inlets/inlets-pro:0.8.1"
-		}
-		return i.ProConfig.ClientImage
+	if i.ProConfig.ClientImage == "" {
+		return "ghcr.io/inlets/inlets-pro:0.8.1"
 	}
-
-	if i.InletsClientImage == "" {
-		return "inlets/inlets:2.7.10"
-	}
-
-	return i.InletsClientImage
+	return i.ProConfig.ClientImage
 }
 
 // GetAccessKey from parameter or file trimming


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Return errors from provisioner factories

This is something that @maelvls flagged up which happened with
a GCE provisioner with an invalid JSON service token.

https://github.com/inlets/inlets-operator/pull/119/files

## How Has This Been Tested?

Tested by building and running the unit tests.

## How are existing users impacted? What migration steps/scripts do we need?

No change for happy path. When a failure happens for some unexpected reason, the user will now get a log message.
