### PR TITLE
Fix parameter projectID casing

### DIFF
--- a/chart/inlets-operator/README.md
+++ b/chart/inlets-operator/README.md
@@ -65,7 +65,7 @@ Parameter | Description | Default
 `vpcId`                 | The VPC ID to create the exit-server in (EC2) | `""`
 `subnetId`              | The Subnet ID where the exit-server should be placed (EC2) | `""`
 `accessKeyFile`         | Read the access key for your infrastructure provider from a file (recommended)  | `/var/secrets/inlets/inlets-access-key`
-`projectId`             | The project ID if using gce or equinix-metal as the provider    | `""`
+`projectID`             | The project ID if using gce or equinix-metal as the provider    | `""`
 `annotatedOnly`         | Only create a tunnel for annotated services.                                    | `false`
 `resources`             | Operator resources requests & limits                                            | `{"requests":{"cpu": "100m", "memory": "128Mi"}}`
 `nodeSelector`          | Node labels for data pod assignment                                             | `{}`


### PR DESCRIPTION
The helm parameter `projectID` has the wrong casing `projectId` in the chart parameters table.

Signed-off-by: Joni Collinge <jonathancollinge@live.com>

<!-- All PRs raised must follow the contribution guide including -->
<!--raising an issue to propose changes.                         -->

- [ ] I have raised an issue to propose this change.

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
