### PR TITLE
Use Debian 13 for Hetzner instances

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -866,8 +866,8 @@ func getHostConfig(c *Controller, tunnel *inletsv1alpha1.Tunnel, service *corev1
 	case "hetzner":
 		host = provision.BasicHost{
 			Name:       tunnel.Name,
-			OS:         "ubuntu-22.04", // https://docs.hetzner.cloud/#images-get-all-images
-			Plan:       "cx23",         // https://docs.hetzner.cloud/#server-types-get-a-server-type
+			OS:         "debian-13", // https://docs.hetzner.cloud/#images-get-all-images
+			Plan:       "cx23",      // https://docs.hetzner.cloud/#server-types-get-a-server-type
 			Region:     c.infraConfig.Region,
 			UserData:   userData,
 			Additional: map[string]string{},


### PR DESCRIPTION
## Description

Update the default OS image for Hetzner from ubuntu-22.04 to debian-13.

## How Has This Been Tested?

Tested E2E with an exit tunnel getting provisioned successfully on Hetzner.

## How are existing users impacted? What migration steps/scripts do we need?

No migration needed. New tunnels will use Debian 13 instead of Ubuntu 22.04.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests